### PR TITLE
Fetch all channels from TV7

### DIFF
--- a/tv7.py
+++ b/tv7.py
@@ -41,7 +41,7 @@ class TV7:
     self._last_update = 0
 
     self.catchup_url='https://api.tv.init7.net/api/replay/'
-    self.channel_url='https://api.tv.init7.net/api/tvchannel/'
+    self.channel_url='https://api.tv.init7.net/api/tvchannel/?streaming_type=all'
     self.epg_url='https://api.tv.init7.net/api/epg/'
 
     if session:


### PR DESCRIPTION
By default, the TV7 channel endpoint only returns HLS channels. Passing `streaming_type=all` convinces it to return both HLS and multicast channels. `hls` and `multicast_only` are other valid values.

```
$ curl -s https://api.tv.init7.net/api/tvchannel/ | jq '.results | length'
104

$ curl -s https://api.tv.init7.net/api/tvchannel/\?streaming_type\=all | jq '.results | length'
211
```